### PR TITLE
Add Github action for checking PR guidelines

### DIFF
--- a/.github/workflows/pr-check
+++ b/.github/workflows/pr-check
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+import re
+import os
+import sys
+import json
+import argparse
+from typing import List, Optional
+
+import requests
+from github import Github
+from bs4 import BeautifulSoup
+from commonmark import commonmark
+
+
+class UnexpectedPRFormat(Exception):
+    pass
+
+
+def markdown_to_html_doc(body_md: str) -> BeautifulSoup:
+    body_html = commonmark(body_md)
+    return BeautifulSoup(body_html, 'html.parser')
+
+
+class PullRequest:
+    """A Github Pull Request.
+
+    Entrypoint to guideline check API:
+
+        check_X():  runs a specific check, returns an error string if any.
+        check():    runs all check_X() checks and returns a list of errors.
+    """
+    def __init__(self, gh: Github, repo: str, pr_id: int):
+        self.repo = gh.get_repo(repo)
+        self.pr = self.repo.get_pull(pr_id)
+        self.body = markdown_to_html_doc(self.pr.body)
+
+    def section_by_title(self, title: str) -> List[BeautifulSoup]:
+        """Extracts a "section" of the PR body by its title. A section is a
+        sequence of DOM siblings between any two consecutive headings.
+
+        For example, given:
+
+            ```md
+            # First Section
+
+            Hello World
+
+            # Second Section
+            ```
+
+        we would get:
+
+            >>> pr.section_by_title('First Section')
+            ['\n', <p>Hello World</p>]
+        """
+        headings = [
+            heading
+            for heading in self.body.select('h1,h2,h3,h4,h5,h6')
+            if heading.text.lower() == title.lower()
+        ]
+
+        if len(headings) != 1:
+            raise UnexpectedPRFormat("PR body should have a section titled '{}'.".format(title))
+
+        heading = headings[0]
+
+        elems = []
+        for elem in heading.next_siblings:
+            if not elem.name:
+                # text nodes
+                elems.append(elem)
+                continue
+
+            if re.match(r'h\d', elem.name):
+                # next heading
+                break
+            elems.append(elem)
+
+        return elems
+
+    def check_ids_in_title(self) -> Optional[str]:
+        """Checks that PR title does not include references to issues."""
+        match = re.search(r'#\d+', self.pr.title)
+        if match:
+            return "PR titles shouldn't contain issue IDs, found: '{}'.".format(match.group())
+
+        return None
+
+    def check_change_summary(self) -> Optional[str]:
+        """Checks that a Change Summary section exists."""
+        try:
+            self.section_by_title('Change Summary')
+        except UnexpectedPRFormat as e:
+            return str(e)
+
+        return None
+
+    def check_related_issue_ref(self) -> Optional[str]:
+        """If there are #N references in the 'Related issue number' section, at
+        least one uses a valid Github linking verb, eg fixes."""
+        # cf https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
+        valid_issue_ref_verbs = [
+            'close', 'closes', 'closed',
+            'fix', 'fixes', 'fixed',
+            'resolve', 'resolves', 'resolved',
+        ]
+        try:
+            section = self.section_by_title('Related issue number')
+        except UnexpectedPRFormat as e:
+            return str(e)
+
+        text = ' '.join(e.text for e in section)
+        if not re.search(r'#\d+', text):
+            # ok to not reference anything
+            return None
+
+        # note: we don't actually check whether a #N reference is to an issue;
+        # it might be to another PR or to a discussion.
+        match = re.search(r'(\w+)\s+#(\d+)', text)
+        if not match:
+            return "Issue refs should use valid linking verbs like 'fixes #N'."
+
+        verb, issue_id = match.groups()
+        if verb not in valid_issue_ref_verbs:
+            return "Issue refs should use valid linking verbs like 'fixes #{}' not '{}'.".format(
+                issue_id, match.group()
+            )
+
+        return None
+
+    def check_checklist(self) -> Optional[str]:
+        """Checks that all tasks in the Checklist section are ticked off."""
+        try:
+            section = self.section_by_title('Checklist')
+        except UnexpectedPRFormat as e:
+            return str(e)
+
+        list_items = [
+            li.text.strip()
+            for elem in section if elem.name  # ignore leaf text nodes
+            for li in elem.find_all('li')
+        ]
+        n_incomplete_tasks = sum(1 for li in list_items if li.startswith('[ ]'))
+        if n_incomplete_tasks > 0:
+            return "Complete the remaining {} checklist task(s)".format(n_incomplete_tasks)
+
+        return None
+
+    def check(self) -> List[str]:
+        responses = [
+            self.check_ids_in_title(),
+            self.check_change_summary(),
+            self.check_related_issue_ref(),
+            self.check_checklist(),
+        ]
+        return [e for e in responses if e]
+
+
+def main(args: argparse.Namespace) -> int:
+    token = os.environ['GITHUB_TOKEN'].strip()
+    gh = Github(token)
+    pr = PullRequest(gh=gh, repo=args.repo, pr_id=args.pr_id)
+    errors = pr.check()
+    if not errors:
+        return 0
+
+    print('Thank you for opening a Pull Request!\n')
+    print('Before assigning it for review, please fix the following issue(s):\n')
+    print('- ' + '\n- '.join(errors))
+    return 1
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Runs checks against a PR description.")
+    parser.add_argument('repo', help="Name of the Github repository: [user]/[project]")
+    parser.add_argument('pr_id', type=int, help="Integer ID of the PR to check")
+    args = parser.parse_args()
+    sys.exit(main(args))

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,41 @@
+name: PR Guideline Checks
+
+on:
+  pull_request:
+    types: [opened, reopened, edited]
+
+jobs:
+  pr-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: install PR check dependencies
+        run: |
+          pip install -r ${{ github.workspace }}/.github/workflows/requirements.txt
+
+      - name: Run PR checks
+        id: pr_checks
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_ID=$(echo $GITHUB_REF | cut -d/ -f3)
+          cd ${{ github.workspace }}
+          .github/workflows/pr-check ${{ github.repository }} $PR_ID > pr_checks.txt
+
+      - name: Post comment if checks didn't pass
+        uses: actions/github-script@v5
+        if: steps.pr_checks.outcome == 'failure'
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs')
+            message = fs.readFileSync('pr_checks.txt', 'utf8')
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: message
+            })
+            core.setFailed("Some PR checks failed!")

--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -1,0 +1,3 @@
+PyGithub
+commonmark
+beautifulsoup4

--- a/changes/3500-amirkdv.md
+++ b/changes/3500-amirkdv.md
@@ -1,0 +1,1 @@
+Add Github action for checking PR guidelines


### PR DESCRIPTION
## Change Summary

A new action checks PR title and body on PR open|reopen|update.

It depends on:

- Github API for getting PR title and body
- readthedocs/commonmark.py for converting markdown to html
- beautifulsoup4 for parsing html

Implemented checks: 

- No issue reference in title,
- Correct linking verbs (eg "fix") when mentioning issues in 'Related issue number',
- No incomplete task in 'Checklist'.

## Related issue number

Not yet.

## Checklist

* [ ] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
* [x] `changes/<pull request or issue id>-<github username>.md` file added describing change
  (see [changes/README.md](https://github.com/samuelcolvin/pydantic/blob/master/changes/README.md) for details)
* [x] My PR is ready to review, **please add a comment including the phrase "please review" to assign reviewers**